### PR TITLE
Polite process termination

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+0.11
+-----------
+
+- When tearing down processes (through ``--xkill``), the
+  more polite SIGTERM is used before invoking SIGKILL,
+  allowing the process to cleanly shutdown. See
+  https://github.com/pytest-dev/pytest-xprocess/issues/1
+  for more details.
+
 0.10
 -----------
 

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ pre-configure test-specific databases (Postgres, Couchdb, ...).
 
 Additionally there are two new command line options::
 
-     --xkill  # kills all external processes
+     --xkill  # terminates all external processes
      --xshow  # shows currently running processes and log files
 
 

--- a/example/test_server.py
+++ b/example/test_server.py
@@ -1,10 +1,13 @@
 import os
 import sys
+
 import py
+
 
 server_path = py.path.local(__file__).dirpath("server.py")
 
 pytest_plugins = "pytester"
+
 
 def test_server(xprocess):
     xprocess.ensure("server", lambda cwd:
@@ -16,6 +19,7 @@ def test_server(xprocess):
     c = sock.recv(1)
     assert c == "1".encode("utf8")
 
+
 def test_server2(xprocess):
     xprocess.ensure("server2", lambda cwd:
         ("started", [sys.executable, server_path, 6778]))
@@ -25,6 +29,7 @@ def test_server2(xprocess):
     sock.sendall("world\n".encode("utf8"))
     c = sock.recv(1)
     assert c == "1".encode("utf8")
+
 
 def test_server_env(xprocess):
     """Can return env as third item from preparefunc."""
@@ -39,13 +44,15 @@ def test_server_env(xprocess):
     c = sock.recv(1)
     assert c == "X".encode("utf8")
 
+
 def test_shutdown(xprocess):
     xprocess.getinfo("server3").terminate()
     xprocess.getinfo("server2").terminate()
     xprocess.getinfo("server").terminate()
 
+
 def test_functional_work_flow(testdir):
-    p = testdir.makepyfile("""
+    testdir.makepyfile("""
         import sys
         def test_server(request, xprocess):
             xprocess.ensure("server", lambda cwd:

--- a/example/test_server.py
+++ b/example/test_server.py
@@ -41,9 +41,9 @@ def test_server_env(xprocess):
     assert c == "X".encode("utf8")
 
 def test_shutdown(xprocess):
-    xprocess.getinfo("server3").kill()
-    xprocess.getinfo("server2").kill()
-    xprocess.getinfo("server").kill()
+    xprocess.getinfo("server3").terminate()
+    xprocess.getinfo("server2").terminate()
+    xprocess.getinfo("server").terminate()
 
 def test_functional_work_flow(testdir):
     p = testdir.makepyfile("""

--- a/example/test_server.py
+++ b/example/test_server.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import subprocess
 import py
 
 server_path = py.path.local(__file__).dirpath("server.py")

--- a/pytest_xprocess.py
+++ b/pytest_xprocess.py
@@ -33,7 +33,10 @@ def pytest_cmdline_main(config):
         tw = py.io.TerminalWriter()
         rootdir = getrootdir(config)
         xprocess = XProcess(config, rootdir)
-        return xprocess._killxshow(tw, xkill)
+    if xkill:
+        return xprocess._xkill(tw)
+    if xshow:
+        return xprocess._xshow(tw)
 
 @pytest.fixture(scope="session")
 def xprocess(request):

--- a/pytest_xprocess.py
+++ b/pytest_xprocess.py
@@ -9,7 +9,7 @@ import sys
 import os
 
 
-from xprocess import XProcess, do_killxshow
+from xprocess import XProcess
 print_ = py.builtin.print_
 std = py.std
 
@@ -33,7 +33,7 @@ def pytest_cmdline_main(config):
         tw = py.io.TerminalWriter()
         rootdir = getrootdir(config)
         xprocess = XProcess(config, rootdir)
-        return do_killxshow(xprocess, tw, xkill)
+        return xprocess._killxshow(tw, xkill)
 
 @pytest.fixture(scope="session")
 def xprocess(request):

--- a/pytest_xprocess.py
+++ b/pytest_xprocess.py
@@ -1,6 +1,3 @@
-
-# content of conftest.py
-
 import pytest
 import py
 
@@ -19,9 +16,11 @@ def pytest_addoption(parser):
     group.addoption('--xshow', action="store_true",
         help="show status of external process")
 
+
 def getrootdir(config):
     from pytest_cache import getrootdir
     return getrootdir(config, ".xprocess").ensure(dir=1)
+
 
 def pytest_cmdline_main(config):
     xkill = config.option.xkill
@@ -36,6 +35,7 @@ def pytest_cmdline_main(config):
     if xshow:
         return xprocess._xshow(tw)
 
+
 @pytest.fixture(scope="session")
 def xprocess(request):
     """ Return session-scoped XProcess helper to manage long-running
@@ -43,6 +43,7 @@ def xprocess(request):
     """
     rootdir = getrootdir(request.config)
     return XProcess(request.config, rootdir)
+
 
 @pytest.mark.hookwrapper
 def pytest_runtest_makereport(item, call):
@@ -56,4 +57,3 @@ def pytest_runtest_makereport(item, call):
             longrepr = getattr(report, "longrepr", None)
             if hasattr(longrepr, "addsection"):
                 longrepr.addsection("%s log" %name, content)
-

--- a/pytest_xprocess.py
+++ b/pytest_xprocess.py
@@ -2,16 +2,14 @@
 # content of conftest.py
 
 import pytest
-import subprocess
-import textwrap
 import py
-import sys
-import os
-
 
 from xprocess import XProcess
+
+
 print_ = py.builtin.print_
 std = py.std
+
 
 def pytest_addoption(parser):
     group = parser.getgroup("xprocess",

--- a/xprocess.py
+++ b/xprocess.py
@@ -6,25 +6,6 @@ from py import std
 import psutil
 
 
-def do_killxshow(xprocess, tw, xkill):
-    ret = 0
-    for p in xprocess.rootdir.listdir():
-        info = xprocess.getinfo(p.basename)
-        if xkill:
-            killret = info.kill()
-            ret = ret or (killret==1)
-            if killret == 1:
-                tw.line("%s %s TERMINATED" % (info.pid, info.name))
-            elif killret == -1:
-                tw.line("%s %s FAILED TO KILL" % (info.pid, info.name))
-            elif killret == 0:
-                tw.line("%s %s NO PROCESS FOUND" % (info.pid, info.name))
-        else:
-            running = info.isrunning() and "LIVE" or "DEAD"
-            tw.line("%s %s %s %s" %(info.pid, info.name, running,
-                                        info.logpath,))
-    return ret
-
 class XProcessInfo:
     def __init__(self, path, name):
         self.name = name
@@ -162,3 +143,21 @@ class XProcess:
             if count < 0:
                 return False
 
+    def _killxshow(self, tw, xkill):
+        ret = 0
+        for p in self.rootdir.listdir():
+            info = self.getinfo(p.basename)
+            if xkill:
+                killret = info.kill()
+                ret = ret or (killret==1)
+                if killret == 1:
+                    tw.line("%s %s TERMINATED" % (info.pid, info.name))
+                elif killret == -1:
+                    tw.line("%s %s FAILED TO KILL" % (info.pid, info.name))
+                elif killret == 0:
+                    tw.line("%s %s NO PROCESS FOUND" % (info.pid, info.name))
+            else:
+                running = info.isrunning() and "LIVE" or "DEAD"
+                tw.line("%s %s %s %s" %(info.pid, info.name, running,
+                                            info.logpath,))
+        return ret

--- a/xprocess.py
+++ b/xprocess.py
@@ -6,27 +6,13 @@ import psutil
 
 std = py.std
 
-def do_xkill(info):
-    # return codes:
-    # 0   no work to do
-    # 1   killed
-    # -1  failed to kill
-    if not info.pid or not info.isrunning():
-        return 0
-
-    try:
-        psutil.Process(info.pid).kill()
-    except psutil.Error:
-        return -1
-    else:
-        return 1
 
 def do_killxshow(xprocess, tw, xkill):
     ret = 0
     for p in xprocess.rootdir.listdir():
         info = xprocess.getinfo(p.basename)
         if xkill:
-            killret = do_xkill(info)
+            killret = info.kill()
             ret = ret or (killret==1)
             if killret == 1:
                 tw.line("%s %s TERMINATED" % (info.pid, info.name))
@@ -52,7 +38,19 @@ class XProcessInfo:
             self.pid = None
 
     def kill(self):
-        return do_xkill(self)
+        # return codes:
+        # 0   no work to do
+        # 1   killed
+        # -1  failed to kill
+        if not self.pid or not self.isrunning():
+            return 0
+
+        try:
+            psutil.Process(self.pid).kill()
+        except psutil.Error:
+            return -1
+        else:
+            return 1
 
     def isrunning(self):
         if self.pid is None:

--- a/xprocess.py
+++ b/xprocess.py
@@ -1,3 +1,4 @@
+from __future__ import division
 
 import sys
 import os
@@ -20,13 +21,22 @@ class XProcessInfo:
     def terminate(self):
         # return codes:
         # 0   no work to do
-        # 1   terminate
+        # 1   terminated
         # -1  failed to terminate
+
         if not self.pid or not self.isrunning():
             return 0
 
+        timeout = 20
+
         try:
-            psutil.Process(self.pid).terminate()
+            proc = psutil.Process(self.pid)
+            proc.terminate()
+            try:
+                proc.wait(timeout=timeout/2)
+            except psutil.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=timeout/2)
         except psutil.Error:
             return -1
         else:

--- a/xprocess.py
+++ b/xprocess.py
@@ -143,21 +143,24 @@ class XProcess:
             if count < 0:
                 return False
 
-    def _killxshow(self, tw, xkill):
+    def _xkill(self, tw):
         ret = 0
         for p in self.rootdir.listdir():
             info = self.getinfo(p.basename)
-            if xkill:
-                killret = info.kill()
-                ret = ret or (killret==1)
-                if killret == 1:
-                    tw.line("%s %s TERMINATED" % (info.pid, info.name))
-                elif killret == -1:
-                    tw.line("%s %s FAILED TO KILL" % (info.pid, info.name))
-                elif killret == 0:
-                    tw.line("%s %s NO PROCESS FOUND" % (info.pid, info.name))
-            else:
-                running = info.isrunning() and "LIVE" or "DEAD"
-                tw.line("%s %s %s %s" %(info.pid, info.name, running,
-                                            info.logpath,))
+            killret = info.kill()
+            ret = ret or (killret==1)
+            if killret == 1:
+                tw.line("%s %s TERMINATED" % (info.pid, info.name))
+            elif killret == -1:
+                tw.line("%s %s FAILED TO KILL" % (info.pid, info.name))
+            elif killret == 0:
+                tw.line("%s %s NO PROCESS FOUND" % (info.pid, info.name))
         return ret
+
+    def _xshow(self, tw):
+        for p in self.rootdir.listdir():
+            info = self.getinfo(p.basename)
+            running = info.isrunning() and "LIVE" or "DEAD"
+            tw.line("%s %s %s %s" %(info.pid, info.name, running,
+                                        info.logpath,))
+        return 0

--- a/xprocess.py
+++ b/xprocess.py
@@ -1,10 +1,9 @@
 
 import sys
 import os
-import py
-import psutil
 
-std = py.std
+from py import std
+import psutil
 
 
 def do_killxshow(xprocess, tw, xkill):

--- a/xprocess.py
+++ b/xprocess.py
@@ -143,10 +143,15 @@ class XProcess:
             if count < 0:
                 return False
 
+    def _infos(self):
+        return (
+            self.getinfo(p.basename)
+            for p in self.rootdir.listdir()
+        )
+
     def _xkill(self, tw):
         ret = 0
-        for p in self.rootdir.listdir():
-            info = self.getinfo(p.basename)
+        for info in self._infos():
             killret = info.kill()
             ret = ret or (killret==1)
             if killret == 1:
@@ -158,8 +163,7 @@ class XProcess:
         return ret
 
     def _xshow(self, tw):
-        for p in self.rootdir.listdir():
-            info = self.getinfo(p.basename)
+        for info in self._infos():
             running = info.isrunning() and "LIVE" or "DEAD"
             tw.line("%s %s %s %s" %(info.pid, info.name, running,
                                         info.logpath,))

--- a/xprocess.py
+++ b/xprocess.py
@@ -17,16 +17,16 @@ class XProcessInfo:
         else:
             self.pid = None
 
-    def kill(self):
+    def terminate(self):
         # return codes:
         # 0   no work to do
-        # 1   killed
-        # -1  failed to kill
+        # 1   terminate
+        # -1  failed to terminate
         if not self.pid or not self.isrunning():
             return 0
 
         try:
-            psutil.Process(self.pid).kill()
+            psutil.Process(self.pid).terminate()
         except psutil.Error:
             return -1
         else:
@@ -86,7 +86,7 @@ class XProcess:
 
         if restart:
             if info.pid is not None:
-                info.kill()
+                info.terminate()
             controldir = info.controldir.ensure(dir=1)
             #controldir.remove()
             preparedata = preparefunc(controldir)
@@ -152,13 +152,13 @@ class XProcess:
     def _xkill(self, tw):
         ret = 0
         for info in self._infos():
-            killret = info.kill()
-            ret = ret or (killret==1)
-            if killret == 1:
+            termret = info.terminate()
+            ret = ret or (termret==1)
+            if termret == 1:
                 tw.line("%s %s TERMINATED" % (info.pid, info.name))
-            elif killret == -1:
-                tw.line("%s %s FAILED TO KILL" % (info.pid, info.name))
-            elif killret == 0:
+            elif termret == -1:
+                tw.line("%s %s FAILED TO TERMINATE" % (info.pid, info.name))
+            elif termret == 0:
                 tw.line("%s %s NO PROCESS FOUND" % (info.pid, info.name))
         return ret
 

--- a/xprocess.py
+++ b/xprocess.py
@@ -147,7 +147,7 @@ class XProcess:
                 raise RuntimeError("Could not start process %s" % name)
         logfiles = self.config.__dict__.setdefault("_extlogfiles", {})
         logfiles[name] = f
-        newinfo = self.getinfo(name)
+        self.getinfo(name)
         return info.pid, info.logpath
 
     def _checkpattern(self, f, pattern, count=50):


### PR DESCRIPTION
This change uses the more polite `.terminate` to end processes and only resorts to `.kill` if the terminate doesn't happen in short order (currently hard-coded to 10 sec for terminate then 10 sec for kill).

Preceding the changes are several refactoring commits that I believe improve the code hygiene but also helped me understand the code model. They're not strictly necessary, but I think they're worth having. If it would be easier to request those separately, I can do that on request. The three commits that reference #1 are the most pertinent.