### PR TITLE
Extract ProcessStarter class for defining startup behavior

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+0.12
+----
+
+- #3: :method:`XProcess.ensure` now accepts preferably
+  a ProcessStarter subclass to define and customize the
+  process startup behavior.
+
 0.11.1
 ------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,8 @@
 
 - #3: :method:`XProcess.ensure` now accepts preferably
   a ProcessStarter subclass to define and customize the
-  process startup behavior.
+  process startup behavior. Passing a simple function is
+  deprecated and will be removed in a future release.
 
 0.11.1
 ------

--- a/README.rst
+++ b/README.rst
@@ -46,19 +46,20 @@ The ``Starter`` is a subclass that gets initialized with the working
 directory created for this process.  If the server has not yet been
 started:
 
-- the ``args`` are used to invoke a new subprocess with
-  environment ``env`` (a mapping) and redirect its stdout to a new logfile.
+- the ``args`` are used to invoke a new subprocess.
 
 - the ``pattern`` is waited for in the logfile before returning.
   It should thus match a state of your server where it is ready to
   answer queries.
 
-- the logfile is returned pointing to the line right after the match
+- ``env`` may be defined to customize the environment in which the
+  new subprocess is invoked. To inherit the main test process
+  environment, leave ``env`` set to the default (``None``).
+
+- stdout is redirected to a logfile, which is returned pointing to the
+  line right after the match
 
 else, if the server is already running simply the logfile is returned.
-
-To inherit the main test process environment, leave ``env`` set to the
-default (``None``).
 
 To customize the startup behavior, override other methods of the
 ProcessStarter. For example, to extend the number of lines searched

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,7 @@ uses the ``xprocess`` fixture internally::
     # content of conftest.py
 
     import pytest
+    from pytest_xprocess import ProcessStarter
 
     @pytest.fixture
     def myserver(xprocess):

--- a/xprocess.py
+++ b/xprocess.py
@@ -171,6 +171,11 @@ class XProcess:
 
 
 class ProcessStarter(object):
+    """
+    Describes the characteristics of a process to start, waiting
+    for a process to achieve a started state.
+    """
+
     env = None
     """
     The environment in which to invoke the process.

--- a/xprocess.py
+++ b/xprocess.py
@@ -206,6 +206,13 @@ class ProcessStarter(object):
 
 
 class CompatStarter(ProcessStarter):
+    """
+    A compatibility ProcessStarter to handle legacy preparefunc
+    and warn of the deprecation.
+    """
+
+    # Define properties to satisfy the abstract property, though
+    # they will be overridden at the instance.
     pattern = None
     args = None
 

--- a/xprocess.py
+++ b/xprocess.py
@@ -234,4 +234,6 @@ class CompatStarter(ProcessStarter):
         """
         if isinstance(starter_cls, type) and issubclass(starter_cls, ProcessStarter):
             return starter_cls
+        depr_msg = 'Pass a ProcessStarter for preparefunc'
+        warnings.warn(depr_msg, DeprecationWarning, stacklevel=3)
         return functools.partial(CompatStarter, starter_cls)

--- a/xprocess.py
+++ b/xprocess.py
@@ -11,6 +11,11 @@ from py import std
 import psutil
 
 
+# make map appear from the future
+if sys.version_info < (3,):
+    map = itertools.imap
+
+
 class XProcessInfo:
     def __init__(self, path, name):
         self.name = name
@@ -185,17 +190,19 @@ class ProcessStarter(object):
 
     def wait(self, log_file):
         "Wait until the process is ready."
+        lines = map(self.log_line, self.filter_lines(self.get_lines(log_file)))
         return any(
             std.re.search(self.pattern, line)
-            for line in self.filter_lines(self.get_lines(log_file))
+            for line in lines
         )
 
     def filter_lines(self, lines):
         # only consider the first 50 lines
-        limit = itertools.islice(lines, 50)
-        for line in limit:
-            self.process.log.debug(line)
-            yield line
+        return itertools.islice(lines, 50)
+
+    def log_line(self, line):
+        self.process.log.debug(line)
+        return line
 
     def get_lines(self, log_file):
         while True:


### PR DESCRIPTION
Following the discussion in #4, I felt like the interface for startup behavior was getting overly complicated and difficult to manage. This approach takes a different tack and creates an encapsulated, formal interface for defining startup behavior. It consolidates the different hook points one might want to customize (reading lines, filtering lines, logging lines, and waiting in general), obviating the various interfaces from before. No longer does the code have:

- preparefunc returning positional arguments with two accepted forms.
- preparefunc `wait` result being either a function taking no arguments or being a regex string.
- the temptation to add more parameters to tweak the behavior.

The docs provide an example showing how one might address #3 by overriding filter_lines.

To maintain compatibility, I introduced a CompatStarter that will translate the former preparefunc interface to a concrete ProcessStarter subclass, with a message signaling the user to replace it.

I almost gave up on this effort, but now that I have it, I'm fairly happy with it, and I'd prefer it over #4. I welcome feedback of all sorts.