### PR TITLE
Ci setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+language: python
+python:
+  - '2.6'
+  - '2.7'
+  - '3.4'
+
+install:
+  - pip install tox-travis
+script:
+  - tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+environment:
+  matrix:
+  - TOXENV: "py26"
+  - TOXENV: "py27"
+  - TOXENV: "py34"
+
+install:
+  - C:\Python36\python -m pip install tox
+
+build: false  # Not a C# project, build stuff at the test step instead.
+
+test_script:
+  - C:\Python36\python -m tox

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,17 @@ if __name__ == "__main__":
         py_modules=['pytest_xprocess', 'xprocess'],
         entry_points={'pytest11': ['xprocess = pytest_xprocess']},
         install_requires=['pytest-cache', 'pytest>=2.3.5', 'psutil'],
+        classifiers = [
+            'Development Status :: 4 - Beta',
+            'Intended Audience :: Developers',
+            'License :: OSI Approved :: MIT License',
+            'Operating System :: POSIX',
+            'Operating System :: Microsoft :: Windows',
+            'Topic :: Software Development :: Testing',
+            'Topic :: Software Development :: Libraries',
+            'Topic :: Utilities',
+            'Programming Language :: Python :: 2.6',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3.4',
+        ],
     )

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,8 @@ changedir=example
 deps =
     pytest>=2.7.2
 
-commands= 
+commands=
     py.test -v
 
 [testenv:py27-old]
 deps= pytest==2.6.4
-
-[testenv:py26]
-platform = linux
-


### PR DESCRIPTION
Add CI configuration

The general configuration is a little outdated (only Python 3.4). I plan to update it in another PR.

I suggest supporting py27, py35 and py36 (dropping 2.6 and 3.4), what do you guys think?