### PR TITLE
Fixed iteration over the process logs to properly skip empty lines

### DIFF
--- a/xprocess.py
+++ b/xprocess.py
@@ -206,6 +206,7 @@ class ProcessStarter(object):
             line = log_file.readline()
             if not line:
                 std.time.sleep(0.1)
+                continue
             yield line
 
 


### PR DESCRIPTION
When log line was empty, it was still returned after 0.1s. The proper behaviour would be to skip the empty log line and read it again (until there is a valid content that can be returned).