### PR TITLE
Release 0.14.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,51 +1,44 @@
-0.14.0
-------
-Unreleased
+0.14.0 (2020-09-24)
+-------------------
 
 - Now ``XProcessInfo.terminate`` will by default also terminate the entire
   process tree. This is safer as there's no risk of leaving lingering processes
   behind. If for some reason you need the previous behavior of only terminating
   the root process, pass ```kill_proc_tree=False`` to ``XProcessInfo.terminate``.
 
-0.13.1
-------
-released Jan 29
+0.13.1 (2020-01-29)
+-------------------
 
 - Drop support for Python 2.6 and 3.4.
 
 - Ignore empty lines in log files when looking for the pattern that indicates
   a process has started.
 
-0.13.0
-------
-Unreleased
+0.13.0 (UNRELEASED)
+-------------------
 
 - Never released due to deploy issues.
 
-0.12.1
-------
-Released Jun 7, 2017
+0.12.1 (2017-06-07)
+-------------------
 
 - Fixed example in README.md
 
-0.12
-----
-Relased Jun 6, 2017
+0.12.0 (2017-06-06)
+-------------------
 
 - #3: :meth:`XProcess.ensure` now accepts preferably a ProcessStarter
   subclass to define and customize the process startup behavior. Passing a
   simple function is deprecated and will be removed in a future release.
 
-0.11.1
-------
-Released May 31, 2017
+0.11.1 (2017-05-31)
+-------------------
 
 - Restored :meth:`XProcessInfo.kill()` as alias for
   :meth:`XProcessInfo.terminate()` for API compatibility.
 
-0.11
-----
-Released May 18, 2017
+0.11 (2017-05-18)
+-----------------
 
 - When tearing down processes (through ``--xkill``), the
   more polite SIGTERM is used before invoking SIGKILL,
@@ -55,22 +48,19 @@ Released May 18, 2017
 
 - :meth:`XProcessInfo.kill()` is deprecated.
 
-0.10
-----
-Released May 15, 2017
+0.10 (2017-05-15)
+-----------------
 
 - Project `now hosted on Github
   <https://github.com/pytest-dev/pytest-xprocess/>`_.
 
-0.9.1
------
-Released Jul 15, 2015
+0.9.1 (2015-07-15)
+------------------
 
 - Don't use `__multicall__` in pytest hook
 
-0.9
----
-Released Jul 15, 2015
+0.9 (2015-07-15)
+----------------
 
 - Fix issue Log calls without parameters now print the correct message
   instead of an empty tuple. See
@@ -79,9 +69,8 @@ Released Jul 15, 2015
 
 - Use 3rd party `psutil` library for process handling
 
-0.8
----
-Released Oct 4, 2013
+0.8.0 (2013-10-04)
+------------------
 
 - Support python3 (tested on linux/win32)
 
@@ -93,7 +82,7 @@ Released Oct 4, 2013
 
 - Add tests
 
-0.7
+0.7.0 (2013-04-05)
 ---
 
 - Initial release

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,6 @@ author_email = holger@merlinux.eu
 license = MIT
 license_files = LICENSE
 url = https://github.com/pytest-dev/pytest-xprocess/
-version = 0.13.1
 long_description = file: README.rst
 description = A pytest plugin for managing processes across test runs.
 classifiers=


### PR DESCRIPTION
- [x] update ` CHANGELOG.rst`
- [x] update version in `setup.cfg`

I wonder if we should also:

~~remove deprecated code~~
~~remote deprecated code tests~~

The alias for the legacy `XProcessInfo.kill` has been around since version 0.11.1 according to logs, should we get rid of it now?