### PR TITLE
Fix subprocess special chars stdout bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 0.15.0 (UNRELEASED)
 -------------------
 
-- Remove deprecated :meth:`XProcessInfo.kill`
+- Fixed bug when process write certain special characters to stdout
+- Removed deprecated :meth:`XProcessInfo.kill`
 
 0.14.0 (2020-09-24)
 -------------------

--- a/example/server.py
+++ b/example/server.py
@@ -46,6 +46,10 @@ if __name__ == "__main__":
     # `xprocess` (see #13)
     for _ in range(100):
         sys.stderr.write("\n")
+    # Sequence of potentialy troublesome strings to test XProcess.Log.debug
+    # and string matching
+    for i in range(5):
+        sys.stderr.write("{} , % /.%,@%@._%%# #/%/ %\n".format(i))
     sys.stderr.write("started\n")
     sys.stderr.flush()
     mainserver.serve_forever()

--- a/example/test_server.py
+++ b/example/test_server.py
@@ -11,8 +11,9 @@ pytest_plugins = "pytester"
 
 
 def test_server(xprocess):
+    pattern = "2 , % /.%,@%@._%%# #/%/ %\n"
     xprocess.ensure(
-        "server", lambda cwd: ("started", [sys.executable, server_path, 6777])
+        "server", lambda cwd: (pattern, [sys.executable, server_path, 6777])
     )
     import socket
 
@@ -40,9 +41,10 @@ def test_server_env(xprocess):
     """Can return env as third item from preparefunc."""
     env = os.environ.copy()
     env["RESPONSE"] = "X"
+    pattern = "4 , % /.%,@%@._%%# #/%/ %\n"
     xprocess.ensure(
         "server3",
-        lambda cwd: ("started", [sys.executable, server_path, 6779], env),
+        lambda cwd: (pattern, [sys.executable, server_path, 6779], env),
     )
     import socket
 

--- a/xprocess.py
+++ b/xprocess.py
@@ -87,7 +87,10 @@ class XProcess:
 
         class Log:
             def debug(self, msg, *args):
-                print(msg % args)
+                if args:
+                    print(msg % args)
+                else:
+                    print(msg)
 
         self.log = log or Log()
 


### PR DESCRIPTION
- [x] implement fix
- [x] adjust tests to cover complex string patterns with control characters
- [x] provide an explanation for chosen solution

[XprocessInfo.ensure](https://github.com/pytest-dev/pytest-xprocess/blob/f13e1e518ece31e84081becece4684ba2f01afa4/xprocess.py#L150)

```python
if not starter.wait(f):
    raise RuntimeError("Could not start process %s" % name)
    self.log.debug("%s process startup detected", name)
```

A call to [ProcessStarter.wait](https://github.com/pytest-dev/pytest-xprocess/blob/f13e1e518ece31e84081becece4684ba2f01afa4/xprocess.py#L206) is made in order to wait for process initialization.

```python
def wait(self, log_file):
    "Wait until the process is ready."
    lines = map(self.log_line, self.filter_lines(self.get_lines(log_file)))
    return any(std.re.search(self.pattern, line) for line in lines)
```

Here, [self.get_lines](https://github.com/pytest-dev/pytest-xprocess/blob/f13e1e518ece31e84081becece4684ba2f01afa4/xprocess.py#L220) will wait on process output and lines will be tested for a match against the given string pattern. The problem starts when [self.log_line](https://github.com/pytest-dev/pytest-xprocess/blob/f13e1e518ece31e84081becece4684ba2f01afa4/xprocess.py#L216) is applied to the strings by `map`.

```python
def log_line(self, line):
    self.process.log.debug(line)
    return line
```

This, in turn, calls [self.process.log.debug](https://github.com/pytest-dev/pytest-xprocess/blob/f13e1e518ece31e84081becece4684ba2f01afa4/xprocess.py#L89) to write the string to the process file.

```python
class Log:
    def debug(self, msg, *args):
        print(msg % args)
```

And here is where the described problem happens. When called with values like `”{% /.%,@%@._%%# #/%/ %\n”`, `debug` will attempt to replace what python interprets as placeholders (e.g `%<something>`) with passed `args`. But, since arguments have not been passed, this raises `TypeError: not enough arguments for format string`. The simple change I made to prevent this was to only attempt interpolation when arguments were present:

```python
class Log:
    def debug(self, msg, *args):
        if args:
            print(msg % args)
        else:
            print(msg)
```