### PR TITLE
Use cache.makedir instead of dot-directory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 0.15.0 (UNRELEASED)
 -------------------
 
-- pytest-xprocess now uses `config.cache` to store process related files
+- pytest-xprocess now uses a sub-directory of `.pytest_cache` to store process related files.
 - Drop support for Python 2.7
 - Fixed bug when non-ascii characters were written to stdout by external
   process

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 0.15.0 (UNRELEASED)
 -------------------
 
+- pytest-xprocess now uses `config.cache` to store process related files
 - Drop support for Python 2.7
 - Fixed bug when non-ascii characters were written to stdout by external
   process

--- a/pytest_xprocess.py
+++ b/pytest_xprocess.py
@@ -15,14 +15,14 @@ def pytest_addoption(parser):
 
 
 def getrootdir(config):
-    return config.rootdir.join(".xprocess").ensure(dir=1)
+    return config.cache.makedir(".xprocess")
 
 
 def pytest_cmdline_main(config):
     xkill = config.option.xkill
     xshow = config.option.xshow
     if xkill or xshow:
-        # config._do_configure()
+        config._do_configure()
         tw = py.io.TerminalWriter()
         rootdir = getrootdir(config)
         xprocess = XProcess(config, rootdir)


### PR DESCRIPTION
- [x] update `pytest_xprocess.py` to use `config.cache`
- [x] add changelog