### PR TITLE
Move requirements to setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,9 +25,6 @@ classifiers=
 universal = 1
 
 [options]
-install_requires=
-    pytest>=2.8
-    psutil
 setup_requires=
     setuptools_scm
 py_modules=

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
 from setuptools import setup
 
 if __name__ == "__main__":
-    setup(use_scm_version=True)
+    setup(
+        name="pytest-xprocess",
+        use_scm_version=True,
+        # this is for GitHub's dependency graph
+        install_requires=["pytest>=2.8", "psutil"],
+    )


### PR DESCRIPTION
- [x] move `install_requires` to [setup.py](https://github.com/pytest-dev/pytest-xprocess/blob/master/setup.py) for Github's dependency graph