### PR TITLE
release 0.16.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 0.16.0 (2020-10-29)
 -------------------
 
-- :class:`ProcessStarter` now has a new `timeout` class variable optionaly overridden to define the maximum time :meth:`xprocess.ensure` should wait for process output when trying to match :attr:`ProcessStarter.pattern`
+- :class:`ProcessStarter` now has a new `timeout` class variable optionaly overridden to define the maximum time :meth:`xprocess.ensure` should wait for process output when trying to match :attr:`ProcessStarter.pattern`. Defaults to 120 seconds.
 - The number of lines in the process logfile watched for :attr:`ProcessStarter.pattern` is now configurable and can be changed by setting :attr:`ProcessStarter.max_read_lines` to the desired value. Defaults to 50 lines.
 - Make :meth:`XProcessInfo.isrunning` ignore zombie processes by default. Pass ``ignore_zombies=False`` to get the previous behavior, which was to consider zombie processes as running.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-0.16.0 (UNRELEASED)
+0.16.0 (2020-10-29)
 -------------------
 
 - :class:`ProcessStarter` now has a new `timeout` class variable optionaly overridden to define the maximum time :meth:`xprocess.ensure` should wait for process output when trying to match :attr:`ProcessStarter.pattern`

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ uses ``xprocess`` internally:
             args = ['command', 'arg1', 'arg2']
 
             # max startup waiting time
-            # optional, defaults to 30 seconds
+            # optional, defaults to 120 seconds
             timeout = 45
 
             # max lines read from stdout when matching pattern


### PR DESCRIPTION
Our 0.16.0 release  🎉 


**Changes**
- `ProcessStarter` now has a new `timeout` class variable which can optionaly be overridden to define the maximum time :meth:`xprocess.ensure` should wait for process output when trying to match :attr:`ProcessStarter.pattern`

- The number of lines in the process logfile watched for `ProcessStarter.pattern` is now configurable and can be changed by setting `ProcessStarter.max_read_lines` to the desired value. Defaults to 50 lines.

- `XProcessInfo.isrunning` now ignores zombie processes by default. Pass ``ignore_zombies=False`` to get the previous behavior, which was to consider zombie processes as running.