### PR TITLE
add a startup callback to ProcessStarter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,13 @@
+0.17.0 (UNRELEASED)
+-------------------
+
+- :class:`ProcessStarter` now has :meth:`startup_callback`. This method can be optionaly overridden and will be called upon to check process responsiveness
+  after :attr:`ProcessStarter.pattern` is matched. By default, :meth:`XProcess.ensure` will only attempt to match :attr:`ProcessStarter.pattern` when starting a process, if matched, xprocess
+  will consider the process as ready to answer querries. If :meth:`startup_callback` is provided though, its return value will also be considered to determine if the process has been
+  successfully started. If :meth:`startup_callback` returns `True` after :attr:`ProcessStarter.pattern` has been matched, :meth:`XProcess.ensure` will return sucessfully. In contrast, if
+  :meth:`startup_callback` returns `False` after :attr:`ProcessStarter.pattern` has been matched :meth:`XProcess.ensure` will raise a `RuntimeError` exception.
+
+
 0.16.0 (2020-10-29)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,11 @@
 0.17.0 (UNRELEASED)
 -------------------
 
-- :class:`ProcessStarter` now has :meth:`startup_callback`. This method can be optionaly overridden and will be called upon to check process responsiveness
+- :class:`ProcessStarter` now has :meth:`startup_check`. This method can be optionaly overridden and will be called upon to check process responsiveness
   after :attr:`ProcessStarter.pattern` is matched. By default, :meth:`XProcess.ensure` will only attempt to match :attr:`ProcessStarter.pattern` when starting a process, if matched, xprocess
-  will consider the process as ready to answer querries. If :meth:`startup_callback` is provided though, its return value will also be considered to determine if the process has been
-  successfully started. If :meth:`startup_callback` returns `True` after :attr:`ProcessStarter.pattern` has been matched, :meth:`XProcess.ensure` will return sucessfully. In contrast, if
-  :meth:`startup_callback` does not return `True` before timing out, :meth:`XProcess.ensure` will raise a `TimeoutError` exception.
+  will consider the process as ready to answer querries. If :meth:`startup_check` is provided though, its return value will also be considered to determine if the process has been
+  successfully started. If :meth:`startup_check` returns `True` after :attr:`ProcessStarter.pattern` has been matched, :meth:`XProcess.ensure` will return sucessfully. In contrast, if
+  :meth:`startup_check` does not return `True` before timing out, :meth:`XProcess.ensure` will raise a `TimeoutError` exception.
 
 
 0.16.0 (2020-10-29)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@
   after :attr:`ProcessStarter.pattern` is matched. By default, :meth:`XProcess.ensure` will only attempt to match :attr:`ProcessStarter.pattern` when starting a process, if matched, xprocess
   will consider the process as ready to answer querries. If :meth:`startup_callback` is provided though, its return value will also be considered to determine if the process has been
   successfully started. If :meth:`startup_callback` returns `True` after :attr:`ProcessStarter.pattern` has been matched, :meth:`XProcess.ensure` will return sucessfully. In contrast, if
-  :meth:`startup_callback` returns `False` after :attr:`ProcessStarter.pattern` has been matched :meth:`XProcess.ensure` will raise a `RuntimeError` exception.
+  :meth:`startup_callback` does not return `True` before timing out, :meth:`XProcess.ensure` will raise a `TimeoutError` exception.
 
 
 0.16.0 (2020-10-29)

--- a/README.rst
+++ b/README.rst
@@ -98,13 +98,17 @@ internally. Following are two examples:
                 """
                 Optional callback used to check process responsiveness
                 after the provided pattern has been matched. Returned
-                value must be either True or False, where:
+                value must be a boolean, where:
 
                 True: Process has been sucessfuly started and is ready
                       to answer queries.
 
-                False: Callback failed during process startup, RuntimeError
-                       exception will be raised.
+                False: Callback failed during process startup.
+
+                This method will be called multiple times to check if the
+                process is ready to answer queries. A 'TimeoutError' exception
+                will be raised if the provied 'startup_callback' does not
+                return 'True' before 'timeout' seconds.
                 """
                 sock = socket.socket()
                 sock.connect(("localhost", 6777))
@@ -148,15 +152,14 @@ information to start a process instance will be provided:
 
 - ``startup_callback`` when provided will be called upon to check process
   responsiveness after ``ProcessStarter.pattern`` is matched. By default,
-  ``XProcess.ensure`` will attempt to match ProcessStarter.pattern when
+  ``XProcess.ensure`` will attempt to match ``ProcessStarter.pattern`` when
   starting a process, if matched, xprocess will consider the process as ready
   to answer querries. If ``startup_callback`` is provided though, its return
   value will also be considered to determine if the process has been
   properly started. If ``startup_callback`` returns True after
   ``ProcessStarter.pattern`` has been matched, ``XProcess.ensure`` will return
-  sucessfully. In contrast, if ``startup_callback`` returns False after
-  ``ProcessStarter.pattern`` has been matched, ``XProcess.ensure`` will raise a
-  RuntimeError exception.
+  sucessfully. In contrast, if ``startup_callback`` does not return ``True``
+  before timing out, ``XProcess.ensure`` will raise a ``TimeoutError`` exception.
 
 - Adicionally, ``env`` may be defined to customize the environment in which the
   new subprocess is invoked. To inherit the main test process

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ internally. Following are two examples:
             # optional, defaults to 50 lines
             max_read_lines = 100
 
-            def startup_callback(self):
+            def startup_check(self):
                 """
                 Optional callback used to check process responsiveness
                 after the provided pattern has been matched. Returned
@@ -107,7 +107,7 @@ internally. Following are two examples:
 
                 This method will be called multiple times to check if the
                 process is ready to answer queries. A 'TimeoutError' exception
-                will be raised if the provied 'startup_callback' does not
+                will be raised if the provied 'startup_check' does not
                 return 'True' before 'timeout' seconds.
                 """
                 sock = socket.socket()
@@ -150,15 +150,15 @@ information to start a process instance will be provided:
   the first 50 lines of stdout are redirected to a logfile, which is returned
   pointing to the line right after the ``pattern`` match.
 
-- ``startup_callback`` when provided will be called upon to check process
+- ``startup_check`` when provided will be called upon to check process
   responsiveness after ``ProcessStarter.pattern`` is matched. By default,
   ``XProcess.ensure`` will attempt to match ``ProcessStarter.pattern`` when
   starting a process, if matched, xprocess will consider the process as ready
-  to answer querries. If ``startup_callback`` is provided though, its return
+  to answer queries. If ``startup_check`` is provided though, its return
   value will also be considered to determine if the process has been
-  properly started. If ``startup_callback`` returns True after
+  properly started. If ``startup_check`` returns True after
   ``ProcessStarter.pattern`` has been matched, ``XProcess.ensure`` will return
-  sucessfully. In contrast, if ``startup_callback`` does not return ``True``
+  sucessfully. In contrast, if ``startup_check`` does not return ``True``
   before timing out, ``XProcess.ensure`` will raise a ``TimeoutError`` exception.
 
 - Adicionally, ``env`` may be defined to customize the environment in which the

--- a/example/test_server.py
+++ b/example/test_server.py
@@ -196,7 +196,7 @@ def test_callback_success(xprocess):
         pattern = "started"
         args = [sys.executable, server_path, 6777, "--no-children"]
 
-        def startup_callback(self):
+        def startup_check(self):
             sock = socket.socket()
             sock.connect(("localhost", 6777))
             sock.sendall(b"hello\n")
@@ -214,7 +214,7 @@ def test_callback_fail(xprocess):
         pattern = "started"
         args = [sys.executable, server_path, 6777, "--no-children"]
 
-        def startup_callback(self):
+        def startup_check(self):
             sock = socket.socket()
             sock.connect(("localhost", 6777))
             sock.sendall(b"hello\n")

--- a/example/test_server.py
+++ b/example/test_server.py
@@ -210,6 +210,7 @@ def test_callback_success(xprocess):
 
 def test_callback_fail(xprocess):
     class Starter(ProcessStarter):
+        timeout = 5
         pattern = "started"
         args = [sys.executable, server_path, 6777, "--no-children"]
 
@@ -220,6 +221,6 @@ def test_callback_fail(xprocess):
             c = sock.recv(1)
             return c == b"wrong"
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TimeoutError):
         xprocess.ensure("server", Starter)
     xprocess.getinfo("server").terminate()

--- a/example/test_server.py
+++ b/example/test_server.py
@@ -189,3 +189,37 @@ def test_timeout(xprocess):
         ConnectionResetError,
     ):  # Server is terminated
         pass
+
+
+def test_callback_success(xprocess):
+    class Starter(ProcessStarter):
+        pattern = "started"
+        args = [sys.executable, server_path, 6777, "--no-children"]
+
+        def startup_callback(self):
+            sock = socket.socket()
+            sock.connect(("localhost", 6777))
+            sock.sendall(b"hello\n")
+            c = sock.recv(1)
+            return c == b"1"
+
+    xprocess.ensure("server", Starter)
+    assert xprocess.getinfo("server").isrunning()
+    xprocess.getinfo("server").terminate()
+
+
+def test_callback_fail(xprocess):
+    class Starter(ProcessStarter):
+        pattern = "started"
+        args = [sys.executable, server_path, 6777, "--no-children"]
+
+        def startup_callback(self):
+            sock = socket.socket()
+            sock.connect(("localhost", 6777))
+            sock.sendall(b"hello\n")
+            c = sock.recv(1)
+            return c == b"wrong"
+
+    with pytest.raises(RuntimeError):
+        xprocess.ensure("server", Starter)
+    xprocess.getinfo("server").terminate()

--- a/xprocess.py
+++ b/xprocess.py
@@ -14,7 +14,7 @@ from py import std
 
 
 class XProcessInfo:
-    """Holds Information of an active process instance represented by
+    """Holds information of an active process instance represented by
     a XProcess Object and offers recursive termination functionality of
     said process tree."""
 
@@ -157,6 +157,7 @@ class XProcess:
             f.seek(0, 2)
         else:
             if not starter.wait(f):
+                # TODO: update error message for callback
                 raise RuntimeError(
                     "Could not start process {}, the specified "
                     "log pattern was not found within {} lines.".format(
@@ -226,10 +227,15 @@ class ProcessStarter(ABC):
         "The pattern to match when the process has started."
         raise NotImplementedError
 
+    def startup_callback(self):
+        "Used to assert process responsiveness after pattern match"
+        return True
+
     def wait(self, log_file):
-        "Wait until the pattern is mached."
+        "Wait until the pattern is mached and invoke callback."
         lines = map(self.log_line, self.filter_lines(self.get_lines(log_file)))
-        return any(std.re.search(self.pattern, line) for line in lines)
+        has_match = any(std.re.search(self.pattern, line) for line in lines)
+        return has_match and self.startup_callback()
 
     def filter_lines(self, lines):
         """fetch first <max_read_lines>, ignoring blank lines."""

--- a/xprocess.py
+++ b/xprocess.py
@@ -8,6 +8,7 @@ from abc import ABC
 from abc import abstractmethod
 from datetime import datetime
 from datetime import timedelta
+from time import sleep
 
 import psutil
 from py import std
@@ -235,6 +236,7 @@ class ProcessStarter(ABC):
         callback funtion. Will raise TimeoutError if self.callback does not
         return True before self.timeout seconds"""
         while True:
+            sleep(0.1)
             if self.startup_check():
                 return True
             if datetime.now() > self._max_time:

--- a/xprocess.py
+++ b/xprocess.py
@@ -226,7 +226,7 @@ class ProcessStarter(ABC):
         """The pattern to be matched when process is starting."""
         raise NotImplementedError
 
-    def startup_callback(self):
+    def startup_check(self):
         """Used to assert process responsiveness after pattern match"""
         return True
 
@@ -235,7 +235,7 @@ class ProcessStarter(ABC):
         callback funtion. Will raise TimeoutError if self.callback does not
         return True before self.timeout seconds"""
         while True:
-            if self.startup_callback():
+            if self.startup_check():
                 return True
             if datetime.now() > self._max_time:
                 raise TimeoutError(


### PR DESCRIPTION
Following #55, this provides `ProcessStarter.startup_callback` to check process state during `xprocess.ensure` call after `ProcessStarter.pattern` has been matched. As described in `CHANGELOG.rst`:

> `ProcessStarter` now has `startup_callback`. This method can be optionaly overridden and will be called upon to check process responsiveness after `ProcessStarter.pattern` is matched. By default, `XProcess.ensure` will only attempt to match `ProcessStarter.pattern` when starting a process, if matched, xprocess will consider the process as ready to answer querries. If `startup_callback` is provided though, its return value will also be considered to determine if the process has been successfully started. If `startup_callback` returns `True` after `ProcessStarter.pattern` has been matched, `XProcess.ensure` will return sucessfully. In contrast, if `startup_callback` returns `False` after `ProcessStarter.pattern` has been matched `XProcess.ensure` will raise a `RuntimeError` exception.

- [x] implement callback functionality
- [x] add new tests
- [x] add `CHANGELOG.rst` entry
- [x] document new feature in `README.rst`