### PR TITLE
release 0.17.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-0.17.0 (UNRELEASED)
+0.17.0 (2020-11-26)
 -------------------
 
 - :class:`ProcessStarter` now has :meth:`startup_check`. This method can be optionaly overridden and will be called upon to check process responsiveness


### PR DESCRIPTION
Our 0.17.0 release 🎉 

**Changes**

- `ProcessStarter` now has `startup_check`. This method can be optionaly overridden and will be called upon to check process responsiveness after `ProcessStarter.pattern` is matched. By default, `XProcess.ensure` will only attempt to match `ProcessStarter.pattern` when starting a process, if matched, xprocess will consider the process as ready to answer queries. If :meth:`startup_check` is provided though, its return value will also be considered to determine if the process has been successfully started. If `startup_check` returns `True` after `ProcessStarter.pattern` has been matched, `XProcess.ensure` will return sucessfully. In contrast, if `startup_check` does not return `True` before timing out, `XProcess.ensure` will raise a `TimeoutError` exception.
- Remove deprecated `xprocess.CompatStarter`
