### PR TITLE
Fix ResourceWarning due to mishandled Popen instance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,8 @@
 0.17.1 (UNRELEASED)
 -------------------
 
-- Fix `ResourceWarning` in :meth:`XProcess.ensure` caused by not waiting on Popen object's exit
-
-
+- Fix `ResourceWarning` in `:meth:XProcess.ensure` caused by not properly
+  waiting on process exit and leaked File handles
 
 0.17.0 (2020-11-26)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+0.17.1 (UNRELEASED)
+-------------------
+
+- Fix `ResourceWarning` in :meth:`XProcess.ensure` caused by not waiting on Popen object's exit
+
+
+
 0.17.0 (2020-11-26)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 pytest-xprocess
 ===============
 
-.. image:: https://img.shields.io/maintenance/yes/2020?color=blue
+.. image:: https://img.shields.io/maintenance/yes/2021?color=blue
     :target: https://github.com/pytest-dev/pytest-xprocess
     :alt: Maintenance
 

--- a/pytest_xprocess.py
+++ b/pytest_xprocess.py
@@ -48,7 +48,7 @@ def pytest_runtest_makereport(item, call):
     if logfiles is None:
         return
     for name in sorted(logfiles):
-        with open(logfiles[name]) as f:
+        with open(str(logfiles[name])) as f:
             content = f.read()
             if content:
                 longrepr = getattr(report, "longrepr", None)

--- a/pytest_xprocess.py
+++ b/pytest_xprocess.py
@@ -48,9 +48,8 @@ def pytest_runtest_makereport(item, call):
     if logfiles is None:
         return
     for name in sorted(logfiles):
-        with open(str(logfiles[name])) as f:
-            content = f.read()
-            if content:
-                longrepr = getattr(report, "longrepr", None)
-                if hasattr(longrepr, "addsection"):  # pragma: no cover
-                    longrepr.addsection("%s log" % name, content)
+        content = logfiles[name].read()
+        if content:
+            longrepr = getattr(report, "longrepr", None)
+            if hasattr(longrepr, "addsection"):  # pragma: no cover
+                longrepr.addsection("%s log" % name, content)

--- a/pytest_xprocess.py
+++ b/pytest_xprocess.py
@@ -48,8 +48,9 @@ def pytest_runtest_makereport(item, call):
     if logfiles is None:
         return
     for name in sorted(logfiles):
-        content = logfiles[name].read()
-        if content:
-            longrepr = getattr(report, "longrepr", None)
-            if hasattr(longrepr, "addsection"):  # pragma: no cover
-                longrepr.addsection("%s log" % name, content)
+        with open(logfiles[name]) as f:
+            content = f.read()
+            if content:
+                longrepr = getattr(report, "longrepr", None)
+                if hasattr(longrepr, "addsection"):  # pragma: no cover
+                    longrepr.addsection("%s log" % name, content)

--- a/pytest_xprocess.py
+++ b/pytest_xprocess.py
@@ -53,3 +53,18 @@ def pytest_runtest_makereport(item, call):
             longrepr = getattr(report, "longrepr", None)
             if hasattr(longrepr, "addsection"):  # pragma: no cover
                 longrepr.addsection("%s log" % name, content)
+
+
+def pytest_unconfigure(config):
+    """Reading processes exit status is a requirement of subprocess module,
+    so each process instance should be properly waited upon. All file handles
+    should also be closed by the end of the test run. This is done in order to
+    avoid ResourceWarnings."""
+    running_procs = getattr(config, "_running_procs", None)
+    if running_procs:
+        for p in running_procs:
+            p.wait(config._proc_wait_timeout)
+    file_handles = getattr(config, "_file_handles", None)
+    if file_handles:
+        for f in file_handles:
+            f.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,19 @@
+import pytest
+
+from xprocess import ProcessStarter
+
 pytest_plugins = "pytester"
+
+
+@pytest.fixture
+def example(xprocess):
+    """fixture for testing ResourceWarnings
+    in test_resource_cleanup.py module"""
+
+    class Starter(ProcessStarter):
+        pattern = "foo"
+        args = ("sh", "-c", "echo foo; sleep 10; echo bar")
+
+    xprocess.ensure("example", Starter)
+    yield
+    xprocess.getinfo("example").terminate()

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    error

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-filterwarnings =
-    error

--- a/tests/test_functional_workflow.py
+++ b/tests/test_functional_workflow.py
@@ -19,6 +19,9 @@ def test_functional_work_flow(testdir):
                 max_read_lines = 200
                 args = [sys.executable, server_path, port]
 
+            # required so test won't hang on pytest_unconfigure
+            request.config._proc_wait_timeout = 1
+
             xprocess.ensure("server", Starter)
 
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
@@ -29,7 +32,9 @@ def test_functional_work_flow(testdir):
     """
         % str(server_path)
     )
+    print("***running test_functional_work_flow 1***")
     result = testdir.runpytest()
+    print("***running test_functional_work_flow 2***")
     result.stdout.fnmatch_lines("*1 passed*")
     result = testdir.runpytest("--xshow")
     result.stdout.fnmatch_lines("*LIVE*")

--- a/tests/test_functional_workflow.py
+++ b/tests/test_functional_workflow.py
@@ -32,9 +32,7 @@ def test_functional_work_flow(testdir):
     """
         % str(server_path)
     )
-    print("***running test_functional_work_flow 1***")
     result = testdir.runpytest()
-    print("***running test_functional_work_flow 2***")
     result.stdout.fnmatch_lines("*1 passed*")
     result = testdir.runpytest("--xshow")
     result.stdout.fnmatch_lines("*LIVE*")

--- a/tests/test_functional_workflow.py
+++ b/tests/test_functional_workflow.py
@@ -20,7 +20,7 @@ def test_functional_work_flow(testdir):
                 args = [sys.executable, server_path, port]
 
             # required so test won't hang on pytest_unconfigure
-            request.config._proc_wait_timeout = 1
+            xprocess.proc_wait_timeout = 1
 
             xprocess.ensure("server", Starter)
 

--- a/tests/test_resource_cleanup.py
+++ b/tests/test_resource_cleanup.py
@@ -1,12 +1,10 @@
-# Reading processes exit status is a requirement of subprocess module,
-# so each process instance should be properly waited upon. All file handles
-# should also be closed by the end of the test run. This is done in order to
-# avoid ResourceWarnings when env = {'shell': true'} in ProcessStarter"""
-
-
-def test_hello(example):
+def test_0(example):
     pass
 
 
-def test_world(example):
+def test_1(example):
+    pass
+
+
+def test_2(example):
     pass

--- a/tests/test_resource_cleanup.py
+++ b/tests/test_resource_cleanup.py
@@ -1,0 +1,12 @@
+# Reading processes exit status is a requirement of subprocess module,
+# so each process instance should be properly waited upon. All file handles
+# should also be closed by the end of the test run. This is done in order to
+# avoid ResourceWarnings when env = {'shell': true'} in ProcessStarter"""
+
+
+def test_hello(example):
+    pass
+
+
+def test_world(example):
+    pass

--- a/tests/test_startup_timeout.py
+++ b/tests/test_startup_timeout.py
@@ -29,8 +29,6 @@ def cleanup_server_instance(port):
 
 @pytest.mark.parametrize("port,proc_name", [(6777, "s1"), (6778, "s2"), (6779, "s3")])
 def test_timeout_raise_exception(port, proc_name, xprocess, request):
-    request.config._proc_wait_timeout = 60
-
     class Starter(ProcessStarter):
         timeout = 2
         max_read_lines = 500

--- a/tests/test_startup_timeout.py
+++ b/tests/test_startup_timeout.py
@@ -24,10 +24,13 @@ def cleanup_server_instance(port):
         ConnectionResetError,
     ):  # Server is terminated
         pass
+    sock.close()
 
 
 @pytest.mark.parametrize("port,proc_name", [(6777, "s1"), (6778, "s2"), (6779, "s3")])
-def test_timeout_raise_exception(port, proc_name, xprocess):
+def test_timeout_raise_exception(port, proc_name, xprocess, request):
+    request.config._proc_wait_timeout = 60
+
     class Starter(ProcessStarter):
         timeout = 2
         max_read_lines = 500

--- a/tox.ini
+++ b/tox.ini
@@ -36,3 +36,7 @@ basepython = python3.8
 skipsdist = True
 usedevelop = True
 passenv = *
+
+[pytest]
+filterwarnings =
+    error

--- a/xprocess.py
+++ b/xprocess.py
@@ -106,7 +106,7 @@ class XProcess:
         for f in self.log_files:
             f.close()
         for p in self.running_procs:
-            p.wait(30)  # TODO: remove hardcoded wait time
+            p.wait()
 
     def getinfo(self, name):
         """Return Process Info for the given external process."""

--- a/xprocess.py
+++ b/xprocess.py
@@ -87,10 +87,13 @@ class XProcess:
     a set of actions is offered, such as process startup, command line actions
     and information fetching."""
 
-    def __init__(self, config, rootdir, log=None):
-        self.log_files = []
-        self.config = config
+    def __init__(self, config, rootdir, log=None, _proc_wait_timeout=60):
         self.rootdir = rootdir
+
+        self.config = config
+        self.config.__dict__.setdefault("_proc_wait_timeout", _proc_wait_timeout)
+
+        self.log_files = []
         self.running_procs = []
 
         class Log:
@@ -103,10 +106,8 @@ class XProcess:
         self.log = log or Log()
 
     def __del__(self):
-        for f in self.log_files:
-            f.close()
-        for p in self.running_procs:
-            p.wait()
+        self.config.__dict__.setdefault("_running_procs", self.running_procs)
+        self.config.__dict__.setdefault("_file_handles", self.log_files)
 
     def getinfo(self, name):
         """Return Process Info for the given external process."""

--- a/xprocess.py
+++ b/xprocess.py
@@ -100,6 +100,9 @@ class XProcess:
 
         self.log = log or Log()
 
+    def __del__(self):
+        self.popen.wait(20)
+
     def getinfo(self, name):
         """Return Process Info for the given external process."""
         return XProcessInfo(self.rootdir, name)
@@ -141,10 +144,10 @@ class XProcess:
             else:
                 kwargs["close_fds"] = True
                 kwargs["preexec_fn"] = os.setpgrp  # no CONTROL-C
-            popen = Popen(
+            self.popen = Popen(
                 args, cwd=str(controldir), stdout=stdout, stderr=STDOUT, **kwargs
             )
-            info.pid = pid = popen.pid
+            info.pid = pid = self.popen.pid
             info.pidpath.write(str(pid))
             self.log.debug("process %r started pid=%s", name, pid)
             stdout.close()

--- a/xprocess.py
+++ b/xprocess.py
@@ -154,7 +154,7 @@ class XProcess:
             self.log.debug("process %r started pid=%s", name, pid)
             stdout.close()
 
-        with open(info.logpath) as f:
+        with open(str(info.logpath)) as f:
             if not restart:
                 f.seek(0, 2)
             else:


### PR DESCRIPTION
This is a fix for #59

- [x] ~add `__del__` method to `XProcess` where `wait` will be called on all popen instances as per subprocess instructions~
- [x] add new tests to cover case reported on #59
- [x] properly close all file handles
- [x] move cleanup logic from `XProcess.__del__ `to pytest_unconfigured hook
- [x] add changelog entry