### PR TITLE
Add py39 classifier to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers=
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Libraries
     Topic :: Utilities


### PR DESCRIPTION
`py39` is covered by our test suite since #68, this PR only adds it to `setup.cfg` classifiers