### PR TITLE
Drop universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,9 +22,6 @@ classifiers=
     Topic :: Software Development :: Libraries
     Topic :: Utilities
 
-[bdist_wheel]
-universal = 1
-
 [options]
 setup_requires=
     setuptools_scm


### PR DESCRIPTION
Universal wheels are those that support Python 2 and 3, which is not our case.