### PR TITLE
Fix intermittent termination behaviour

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@
   be used for passing keyword values to the `subprocess.Popen` constructor,
   giving the user more control over the initialized process.
 
-0.17.1 (2020-02-28)
+0.17.1 (2021-02-28)
 -------------------
 
 - Fix `ResourceWarning` in :meth:`XProcess.ensure` caused by not properly

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,9 +3,8 @@
 
 - :method:`ProcessInfo.terminate` will now terminate outer leaves in process
   tree first and work its way towards root process. For example, if a process
-  has child, grandchild and great grandchild the order of termination will be:
-  greate grandchild, grandchild, child and only then will the root process
-  receive a termination signal.
+  has child and grandchild, xprocess will terminate first child and grandchild
+  and only then will the root process receive a termination signal.
 
 - :class:`ProcessStarter` now has attr:`terminate_on_interrupt`. This flag will
   make xprocess attempt to terminate and clean up all started process resources

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 0.18.0 (UNRELEASED)
 -------------------
 
+- :method:`ProcessInfo.terminate` will now terminate outer leaves in process
+  tree first and work its way towards root process. For example, if a process
+  has child, grandchild and great grandchild the order of termination will be:
+  greate grandchild, grandchild, child and only then will the root process
+  receive a termination signal.
+
 - :class:`ProcessStarter` now has attr:`terminate_on_interrupt`. This flag will
   make xprocess attempt to terminate and clean up all started process resources
   upon interruptions during pytest runs (CTRL+C, SIGINT and internal errors)

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Useful Links
 --------------
 
 -   Documentation: https://pytest-xprocess.readthedocs.io/
--   Changelog: https://pytest-xprocess.readthedocs.io/changes.html/
+-   Changelog: https://pytest-xprocess.readthedocs.io/en/latest/changes.html
 -   PyPI Releases: https://pypi.org/project/pytest-xprocess/
 -   Source Code: https://github.com/pytest-dev/pytest-xprocess
 -   Issue Tracker: https://github.com/pytest-dev/pytest-xprocess/issues/

--- a/pytest_xprocess.py
+++ b/pytest_xprocess.py
@@ -33,6 +33,7 @@ def pytest_cmdline_main(config):
 def xprocess(request):
     """yield session-scoped XProcess helper to manage long-running
     processes required for testing."""
+
     rootdir = getrootdir(request.config)
     with XProcess(request.config, rootdir) as xproc:
         # pass in xprocess object into pytest_unconfigure

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import socket
+from contextlib import closing
+
 import pytest
 
 from xprocess import ProcessStarter
@@ -17,3 +20,11 @@ def example(xprocess):
     xprocess.ensure("example", Starter)
     yield
     xprocess.getinfo("example").terminate()
+
+
+@pytest.fixture
+def tcp_port():
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        yield s.getsockname()[1]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,4 +27,4 @@ def tcp_port():
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
         s.bind(("", 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        yield s.getsockname()[1]
+        return s.getsockname()[1]

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -9,15 +9,15 @@ from xprocess import ProcessStarter
 server_path = Path(__file__).parent.joinpath("server.py").absolute()
 
 
-@pytest.mark.parametrize("port,proc_name", [(6777, "s1"), (6778, "s2"), (6779, "s3")])
-def test_callback_success(xprocess, port, proc_name):
+@pytest.mark.parametrize("proc_name", ["s1", "s2", "s3"])
+def test_callback_success(xprocess, tcp_port, proc_name):
     class Starter(ProcessStarter):
         pattern = "started"
-        args = [sys.executable, server_path, port, "--no-children"]
+        args = [sys.executable, server_path, tcp_port, "--no-children"]
 
         def startup_check(self):
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-                sock.connect(("localhost", port))
+                sock.connect(("localhost", tcp_port))
                 sock.sendall(bytes("bacon\n", "utf-8"))
                 received = str(sock.recv(1024), "utf-8")
                 return received == "bacon\n".upper()
@@ -28,16 +28,16 @@ def test_callback_success(xprocess, port, proc_name):
     info.terminate()
 
 
-@pytest.mark.parametrize("port,proc_name", [(6777, "s1"), (6778, "s2"), (6779, "s3")])
-def test_callback_fail(xprocess, port, proc_name):
+@pytest.mark.parametrize("proc_name", ["s1", "s2", "s3"])
+def test_callback_fail(xprocess, tcp_port, proc_name):
     class Starter(ProcessStarter):
         timeout = 5
         pattern = "started"
-        args = [sys.executable, server_path, port, "--no-children"]
+        args = [sys.executable, server_path, tcp_port, "--no-children"]
 
         def startup_check(self):
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-                sock.connect(("localhost", port))
+                sock.connect(("localhost", tcp_port))
                 sock.sendall(bytes("bacon\n", "utf-8"))
                 received = str(sock.recv(1024), "utf-8")
                 return received == "wrong"  # this wont match

--- a/tests/test_functional_workflow.py
+++ b/tests/test_functional_workflow.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 
-def test_functional_work_flow(testdir):
+def test_functional_work_flow(testdir, tcp_port):
     server_path = Path(__file__).parent.joinpath("server.py").absolute()
     testdir.makepyfile(
         """
@@ -10,7 +10,7 @@ def test_functional_work_flow(testdir):
         from xprocess import ProcessStarter
 
         def test_server(request, xprocess):
-            port = 6776
+            port = %r
             data = "spam\\n"
             server_path = %r
 
@@ -30,7 +30,7 @@ def test_functional_work_flow(testdir):
                 received = str(sock.recv(1024), "utf-8")
                 assert received == data.upper()
     """
-        % str(server_path)
+        % (tcp_port, str(server_path))
     )
     result = testdir.runpytest()
     result.stdout.fnmatch_lines("*1 passed*")

--- a/tests/test_interruption_clean_up.py
+++ b/tests/test_interruption_clean_up.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 
-def test_interruption_cleanup(testdir):
+def test_interruption_cleanup(testdir, tcp_port):
     server_path = Path(__file__).parent.joinpath("server.py").absolute()
     testdir.makepyfile(
         """
@@ -10,7 +10,7 @@ def test_interruption_cleanup(testdir):
         from xprocess import ProcessStarter
 
         def test_servers_start(request, xprocess):
-            port = 6999
+            port = %r
             server_path = %r
 
             class Starter(ProcessStarter):
@@ -22,7 +22,7 @@ def test_interruption_cleanup(testdir):
 
             raise KeyboardInterrupt
         """
-        % str(server_path)
+        % (tcp_port, str(server_path))
     )
     result = testdir.runpytest_subprocess()
     result.stdout.fnmatch_lines("*KeyboardInterrupt*")
@@ -30,7 +30,7 @@ def test_interruption_cleanup(testdir):
     result.stdout.no_fnmatch_line("*LIVE*")
 
 
-def test_interruption_does_not_cleanup(testdir):
+def test_interruption_does_not_cleanup(testdir, tcp_port):
     server_path = Path(__file__).parent.joinpath("server.py").absolute()
     testdir.makepyfile(
         """
@@ -39,7 +39,7 @@ def test_interruption_does_not_cleanup(testdir):
         from xprocess import ProcessStarter
 
         def test_servers_start(request, xprocess):
-            port = 6990
+            port = %r
             server_path = %r
 
             class Starter(ProcessStarter):
@@ -50,7 +50,7 @@ def test_interruption_does_not_cleanup(testdir):
 
             raise KeyboardInterrupt
         """
-        % str(server_path)
+        % (tcp_port, str(server_path))
     )
     result = testdir.runpytest_subprocess()
     result.stdout.fnmatch_lines("*KeyboardInterrupt*")

--- a/tests/test_process_termination.py
+++ b/tests/test_process_termination.py
@@ -9,11 +9,11 @@ from xprocess import ProcessStarter
 server_path = Path(__file__).parent.joinpath("server.py").absolute()
 
 
-@pytest.mark.parametrize("port,proc_name", [(6777, "s1"), (6778, "s2"), (6779, "s3")])
-def test_clean_shutdown(port, proc_name, xprocess):
+@pytest.mark.parametrize("proc_name", ["s1", "s2", "s3"])
+def test_clean_shutdown(tcp_port, proc_name, xprocess):
     class Starter(ProcessStarter):
         pattern = "started"
-        args = [sys.executable, server_path, port]
+        args = [sys.executable, server_path, tcp_port]
 
     xprocess.ensure(proc_name, Starter)
     info = xprocess.getinfo(proc_name)
@@ -24,11 +24,11 @@ def test_clean_shutdown(port, proc_name, xprocess):
         assert not child.is_running() or child.status() == psutil.STATUS_ZOMBIE
 
 
-@pytest.mark.parametrize("port,proc_name", [(6777, "s1"), (6778, "s2"), (6779, "s3")])
-def test_terminate_no_pid(port, proc_name, xprocess):
+@pytest.mark.parametrize("proc_name", ["s1", "s2", "s3"])
+def test_terminate_no_pid(tcp_port, proc_name, xprocess):
     class Starter(ProcessStarter):
         pattern = "started"
-        args = [sys.executable, server_path, port]
+        args = [sys.executable, server_path, tcp_port]
 
     xprocess.ensure(proc_name, Starter)
     info = xprocess.getinfo(proc_name)
@@ -40,11 +40,11 @@ def test_terminate_no_pid(port, proc_name, xprocess):
     info.terminate()
 
 
-@pytest.mark.parametrize("port,proc_name", [(6777, "s1"), (6778, "s2"), (6779, "s3")])
-def test_terminate_only_parent(port, proc_name, xprocess):
+@pytest.mark.parametrize("proc_name", ["s1", "s2", "s3"])
+def test_terminate_only_parent(tcp_port, proc_name, xprocess):
     class Starter(ProcessStarter):
         pattern = "started"
-        args = [sys.executable, server_path, port]
+        args = [sys.executable, server_path, tcp_port]
 
     xprocess.ensure(proc_name, Starter)
     info = xprocess.getinfo(proc_name)
@@ -62,13 +62,13 @@ def test_terminate_only_parent(port, proc_name, xprocess):
     sys.platform == "win32",
     reason="on windows SIGTERM is treated as an alias for kill()",
 )
-@pytest.mark.parametrize("port,proc_name", [(6777, "s1"), (6778, "s2"), (6779, "s3")])
-def test_sigkill_after_failed_sigterm(port, proc_name, xprocess):
+@pytest.mark.parametrize("proc_name", ["s1", "s2", "s3"])
+def test_sigkill_after_failed_sigterm(tcp_port, proc_name, xprocess):
     # explicitly tell xprocess_starter fixture to make
     # server instance ignore SIGTERM
     class Starter(ProcessStarter):
         pattern = "started"
-        args = [sys.executable, server_path, port, "--ignore-sigterm"]
+        args = [sys.executable, server_path, tcp_port, "--ignore-sigterm"]
 
     xprocess.ensure(proc_name, Starter)
     info = xprocess.getinfo(proc_name)
@@ -80,11 +80,11 @@ def test_sigkill_after_failed_sigterm(port, proc_name, xprocess):
     )
 
 
-@pytest.mark.parametrize("port,proc_name", [(6777, "s1"), (6778, "s2"), (6779, "s3")])
-def test_return_value_on_failure(port, proc_name, xprocess):
+@pytest.mark.parametrize("proc_name", ["s1", "s2", "s3"])
+def test_return_value_on_failure(tcp_port, proc_name, xprocess):
     class Starter(ProcessStarter):
         pattern = "started"
-        args = [sys.executable, server_path, port]
+        args = [sys.executable, server_path, tcp_port]
 
     xprocess.ensure(proc_name, Starter)
     info = xprocess.getinfo(proc_name)

--- a/tests/test_process_termination.py
+++ b/tests/test_process_termination.py
@@ -19,7 +19,7 @@ def test_clean_shutdown(port, proc_name, xprocess):
     info = xprocess.getinfo(proc_name)
     assert info.isrunning()
     children = psutil.Process(info.pid).children()
-    assert info.terminate()
+    assert info.terminate() == 1
     for child in children:
         assert not child.is_running() or child.status() == psutil.STATUS_ZOMBIE
 

--- a/tests/test_startup_timeout.py
+++ b/tests/test_startup_timeout.py
@@ -10,9 +10,9 @@ from xprocess import ProcessStarter
 server_path = Path(__file__).parent.joinpath("server.py").absolute()
 
 
-def cleanup_server_instance(port):
+def cleanup_server_instance(tcp_port):
     sock = socket.socket()
-    sock.connect(("localhost", port))
+    sock.connect(("localhost", tcp_port))
     try:
         for _ in range(10):
             sock.sendall(b"exit\n")
@@ -27,14 +27,14 @@ def cleanup_server_instance(port):
     sock.close()
 
 
-@pytest.mark.parametrize("port,proc_name", [(6777, "s1"), (6778, "s2"), (6779, "s3")])
-def test_timeout_raise_exception(port, proc_name, xprocess, request):
+@pytest.mark.parametrize("proc_name", ["s1", "s2", "s3"])
+def test_timeout_raise_exception(tcp_port, proc_name, xprocess, request):
     class Starter(ProcessStarter):
         timeout = 2
         max_read_lines = 500
         pattern = "will not match"
-        args = [sys.executable, server_path, port, "--no-children"]
+        args = [sys.executable, server_path, tcp_port, "--no-children"]
 
     with pytest.raises(TimeoutError):
         xprocess.ensure(proc_name, Starter)
-    cleanup_server_instance(port)
+    cleanup_server_instance(tcp_port)

--- a/xprocess.py
+++ b/xprocess.py
@@ -85,16 +85,18 @@ class XProcessInfo:
                 self._signal_process(p, signal.SIGKILL)
             _, alive = psutil.wait_procs(kill_list, timeout=timeout)
 
+            # even if termination itself fails,
+            # the signal has been sent to the process
+            self._termination_signal = True
+
             if alive:  # pragma: no cover
                 print("could not terminated process {}".format(alive))
                 return -1
         except (psutil.Error, ValueError) as err:
-            print("Process tree termination error: {}".format(err))
+            print("Error while terminating process {}".format(err))
             return -1
-
-        self._termination_signal = True
-
-        return 1
+        else:
+            return 1
 
     def isrunning(self, ignore_zombies=True):
         """Returns whether the process is running or not.

--- a/xprocess.py
+++ b/xprocess.py
@@ -78,14 +78,15 @@ class XProcessInfo:
             # attempt graceful termination first
             for p in reversed(kill_list):
                 self._signal_process(p, signal.SIGTERM)
-            terminated, alive = psutil.wait_procs(kill_list, timeout=timeout)
+            _, alive = psutil.wait_procs(kill_list, timeout=timeout)
 
             # forcefuly terminate procs still running
             for p in alive:
                 self._signal_process(p, signal.SIGKILL)
-            terminated, alive = psutil.wait_procs(kill_list, timeout=timeout)
+            _, alive = psutil.wait_procs(kill_list, timeout=timeout)
 
             if alive:  # pragma: no cover
+                print("could not terminated process {}".format(alive))
                 return -1
         except (psutil.Error, ValueError) as err:
             print("Process tree termination error: {}".format(err))

--- a/xprocess.py
+++ b/xprocess.py
@@ -63,6 +63,7 @@ class XProcessInfo:
             0   no work to do
             1   terminated
             -1  failed to terminate"""
+
         if not self.pid:
             return 0
         try:
@@ -106,6 +107,7 @@ class XProcessInfo:
                                will become a zombie process during pytest's lifetime.
 
         @return: ``True`` if the process is running, ``False`` if it is not."""
+
         if self.pid is None:
             return False
         try:
@@ -152,6 +154,7 @@ class XProcess:
 
     def getinfo(self, name):
         """Return Process Info for the given external process."""
+
         return XProcessInfo(self.rootdir, name)
 
     def ensure(self, name, preparefunc, restart=False):
@@ -169,6 +172,7 @@ class XProcess:
         @return: (PID, logfile) logfile will be seeked to the end if the
                  server was running, otherwise seeked to the line after
                  where the waitpattern matched."""
+
         from subprocess import Popen, STDOUT
 
         info = self.getinfo(name)
@@ -319,12 +323,14 @@ class ProcessStarter(ABC):
 
     def startup_check(self):
         """Used to assert process responsiveness after pattern match"""
+
         return True
 
     def wait_callback(self):
         """Assert that process is ready to answer queries using provided
         callback funtion. Will raise TimeoutError if self.callback does not
         return True before self.timeout seconds"""
+
         while True:
             sleep(0.1)
             if self.startup_check():
@@ -340,6 +346,7 @@ class ProcessStarter(ABC):
 
     def wait(self, log_file):
         """Wait until the pattern is mached and callback returns successful."""
+
         self._max_time = datetime.now() + timedelta(seconds=self.timeout)
         lines = map(self.log_line, self.filter_lines(self.get_lines(log_file)))
         has_match = any(std.re.search(self.pattern, line) for line in lines)
@@ -348,11 +355,13 @@ class ProcessStarter(ABC):
 
     def filter_lines(self, lines):
         """fetch first <max_read_lines>, ignoring blank lines."""
+
         non_empty_lines = (x for x in lines if x.strip())
         return itertools.islice(non_empty_lines, self.max_read_lines)
 
     def log_line(self, line):
         """Write line to process log file."""
+
         self.process.log.debug(line)
         return line
 
@@ -360,6 +369,7 @@ class ProcessStarter(ABC):
         """Read and yield one line at a time from log_file. Will raise
         TimeoutError if pattern is not matched before self.timeout
         seconds."""
+
         while True:
             line = log_file.readline()
 


### PR DESCRIPTION
In UNIX and UNIX-like systems it's not guaranteed that orphaned processes will be terminated once root process dies. They will usually be adopted by the `init` process which periodically checks for new children and waits on their exit code in order to free allocated resources.

To make `XProcessInfo.terminate` more robust, we will now send termination signals to the outer "leaves" in the process tree first. In order words, if a given process has children and grandchildren, these will be terminated first and only then the root process will receive a termination signal. I have written a more detailed explanation of this in the method  [docstring](https://github.com/pytest-dev/pytest-xprocess/compare/master...northernSage:fix-flaky-termination?expand=1#diff-6f88d574169a6438b98ab7de67fbe2ef6b311c09cf4c49db9a7ef652d7f61d0fR38).

I have also implemented #72 suggestion and now ports are not hard-coded anymore, available ports will be provided by a new fixture [tcp_port](https://github.com/pytest-dev/pytest-xprocess/compare/master...northernSage:fix-flaky-termination?expand=1#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R26)

Lastly, the [_termination_signal](https://github.com/pytest-dev/pytest-xprocess/pull/76/files#diff-6f88d574169a6438b98ab7de67fbe2ef6b311c09cf4c49db9a7ef652d7f61d0fR91) flag will be set even if the termination itself fails and `xprocess` will attempt the clean-up. This seems like the appropriate behaviour once the signal **will have been sent** even if the termination happen to fail due to external reasons. The flag should reflect if the signal was sent or not and let the method return value reflect the outcome of the termination order.