### PR TITLE
Remove _internal.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+0.18.1 (2021-07-27)
+-------------------
+
+- Fix bug with previous release where internal module was missing
+
+
 0.18.0 (2021-07-21)
 -------------------
 

--- a/_internal.py
+++ b/_internal.py
@@ -1,2 +1,0 @@
-def getrootdir(config):
-    return config.cache.makedir(".xprocess")

--- a/pytest_xprocess.py
+++ b/pytest_xprocess.py
@@ -1,8 +1,11 @@
 import py
 import pytest
 
-from _internal import getrootdir
 from xprocess import XProcess
+
+
+def getrootdir(config):
+    return config.cache.makedir(".xprocess")
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
`_internal.py ` seems to not have been bundled in the last release. The file currently has only has a single one-liner function used only in `pytest_xprocess.py` to resolve paths

```python
def getrootdir(config):
    return config.cache.makedir(".xprocess")
```
I don't think an extra module is necessary only for that, so I went ahead and just moved `getrootdir` to `pytest_xprocess.py` and removed `_internal.py`.
