### PR TITLE
Release 0.19.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-0.19.0 (UNRELEASED)
+0.19.0 (2022-05-23)
 -------------------
 
 - drop support for python 3.5 and 3.6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-0.19.0 (2021-12-04)
+0.19.0 (2022-04-16)
 -------------------
 
 - reorganize internals. ``pytest-xprocess`` is now a package and all resources

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-0.19.0 (UNRELEASED)
+0.19.0 (2021-12-04)
 -------------------
 
 - reorganize internals. ``pytest-xprocess`` is now a package and all resources


### PR DESCRIPTION
Our 0.19.0 release 🎉 

**Change summary**

Mostly internal changes. `pytest-xprocess` is now a package in order to avoid issues such as #77 and also, quoting from #85:

> We now have a `XProcessResources` class where all resources used by a running process will be kept. Each `XProcessResources` knows how to clean itself up by using its `release` method and will do so upon exit under normal circumstances through its destructor `__del__`. Upon any interruptions during the test run, the clean-up process will be forced by calling `XProcess._force_clean_up` in our `InterruptionHandler`






