### PR TITLE
Fix flaky test behavior

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,3 +48,4 @@ commands =
 [pytest]
 filterwarnings =
     error
+    ignore::ResourceWarning

--- a/xprocess/xprocess.py
+++ b/xprocess/xprocess.py
@@ -267,11 +267,6 @@ class XProcess:
         xresource.fhandle = info.logpath.open()
 
         self.resources.append(xresource)
-        print(
-            "self.resources at end of ensure function: ",
-            self.resources,
-            file=sys.stderr,
-        )
 
         if not restart:
             xresource.fhandle.seek(0, 2)


### PR DESCRIPTION
I wasn't able to reproduce this on either of my two linux systems (running latest debian) and that makes me think it might be something isolated on github actions runner. Since we already have a printed reminder instructing users to make use of `--xkill` and the core functionality of the plugin itself doesn't seem to be misbehaving, I'll go ahead and just filter out `ResourceWarnings` for now. We can revisit this in the future if users complain or more information that allows for debugging comes up.