### PR TITLE
Add explicit dependency on py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,5 @@ if __name__ == "__main__":
         name="pytest-xprocess",
         use_scm_version=True,
         # this is for GitHub's dependency graph
-        install_requires=["pytest>=2.8", "psutil"],
+        install_requires=["pytest>=2.8", "psutil", "py"],
     )


### PR DESCRIPTION
Without this dependency, xprocess does not work with pytest 7.2.0+

Workaround for #110 
