### PR TITLE
Ignore zombie processes on termination

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+Upcoming
+--------
+
+- Ignore zombie processes which are erroneously considered alive with python 3.11
+  (`#117 <https://github.com/pytest-dev/pytest-xprocess/issues/117>`_)
+
 0.21.0 (2022-11-27)
 -------------------
 

--- a/xprocess/xprocess.py
+++ b/xprocess/xprocess.py
@@ -83,11 +83,13 @@ class XProcessInfo:
             for p in reversed(kill_list):
                 self._signal_process(p, signal.SIGTERM)
             _, alive = psutil.wait_procs(kill_list, timeout=timeout)
+            alive = [a for a in alive if a.status() != psutil.STATUS_ZOMBIE]
 
             # forcefully terminate procs still running
             for p in alive:
                 self._signal_process(p, signal.SIGKILL)
             _, alive = psutil.wait_procs(kill_list, timeout=timeout)
+            alive = [a for a in alive if a.status() != psutil.STATUS_ZOMBIE]
 
             # even if termination itself fails,
             # the signal has been sent to the process


### PR DESCRIPTION
This is a proposed fix for #117. I assumed that it is okay to ignore zombies because the test suite does so, too.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGELOG.rst`, summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and make sure  no tests failed.
