### PR TITLE
Fix resource leak by closing opened file handles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.7", "3.8", "3.9"]
+        python: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
+          - python: "3.10"
+            tox_env: "py310"
           - python: "3.7"
             tox_env: "py37"
           - python: "3.8"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
-Upcoming
---------
+0.22.0 (UNRELEASED)
+-------------------
 
+- Fix resource warnings due to leaked internal file handles (`#121 <https://github.com/pytest-dev/pytest-xprocess/issues/119>`_)
 - Ignore zombie processes which are erroneously considered alive with python 3.11
   (`#117 <https://github.com/pytest-dev/pytest-xprocess/issues/117>`_)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers=
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Libraries
     Topic :: Utilities

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=begin,py{37,38,39}
+envlist=begin,py{37,38,39,310}
 
 [testenv:dev]
 commands =

--- a/xprocess/xprocess.py
+++ b/xprocess/xprocess.py
@@ -273,7 +273,7 @@ class XProcess:
         xresource.fhandle = info.logpath.open()
 
         # skip previous process logs
-        lines = info.logpath.open().readlines()
+        lines = xresource.fhandle.readlines()
         if lines:
             proc_block_counter = sum(
                 1 for line in lines if XPROCESS_BLOCK_DELIMITER in line


### PR DESCRIPTION
Fix #119 

We now just use the already created reference to the opened file stream instead of opening another one. Since, the stream is closed on `XProcessResouce.__del__`, `ResourceWarnings` should no longer show.