### PR TITLE
Make log persistency behavior optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 0.22.0 (UNRELEASED)
 -------------------
 
+- Make log files persistency, added in `0.21.0`, optional, defaulting to True. The previous logging behavior (prior to `0.21.0`) can be
+  enabled by setting `persist_logs` flag to `False` when calling `XProcess.ensure`.
 - Fix resource warnings due to leaked internal file handles (`#121 <https://github.com/pytest-dev/pytest-xprocess/issues/119>`_)
 - Ignore zombie processes which are erroneously considered alive with python 3.11
   (`#117 <https://github.com/pytest-dev/pytest-xprocess/issues/117>`_)


### PR DESCRIPTION
work-around for #120

Using `open` with `errors` introduces different issues with pattern matching and breaks the new logging persistency feature added in `0.21.0`. However, the issue reported in #120 still persists and trash bytes written by initialized process can potently cause problems. I'll need to revisit that implementation and will probably drop `py` module in the process. For now, users having issues with the new logging behavior can opt to go back to the old one by simply calling `ensure` with `persist_logs` set to `False`

`process.ensure(..., persist_logs=False)`