### PR TITLE
Release 0.22.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,9 @@
-0.22.0 (UNRELEASED)
+0.22.0 (2023-01-01)
 -------------------
 
+- Python 3.10 is now officially supported
 - Make log files persistency, added in `0.21.0`, optional, defaulting to True. The previous logging behavior (prior to `0.21.0`) can be
-  enabled by setting `persist_logs` flag to `False` when calling `XProcess.ensure`.
+  enabled by setting `persist_logs` flag to `False` when calling `XProcess.ensure`. (`#122 <https://github.com/pytest-dev/pytest-xprocess/issues/120>`_)
 - Fix resource warnings due to leaked internal file handles (`#121 <https://github.com/pytest-dev/pytest-xprocess/issues/119>`_)
 - Ignore zombie processes which are erroneously considered alive with python 3.11
   (`#117 <https://github.com/pytest-dev/pytest-xprocess/issues/117>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,7 @@
 -------------------
 
 - Python 3.10 is now officially supported
-- Make log files persistency, added in `0.21.0`, optional, defaulting to True. The previous logging behavior (prior to `0.21.0`) can be
-  enabled by setting `persist_logs` flag to `False` when calling `XProcess.ensure`. (`#122 <https://github.com/pytest-dev/pytest-xprocess/issues/120>`_)
+- Make log files persistency, added in `0.21.0`, optional, defaulting to True. The previous logging behavior (prior to `0.21.0`) can be enabled by setting `persist_logs` flag to `False` when calling `XProcess.ensure`. (`#122 <https://github.com/pytest-dev/pytest-xprocess/issues/120>`_)
 - Fix resource warnings due to leaked internal file handles (`#121 <https://github.com/pytest-dev/pytest-xprocess/issues/119>`_)
 - Ignore zombie processes which are erroneously considered alive with python 3.11
   (`#117 <https://github.com/pytest-dev/pytest-xprocess/issues/117>`_)


### PR DESCRIPTION
Our 0.22.0 release 🎉 

Change summary:

- Python 3.10 is now officially supported
- Make log files persistency, added in `0.21.0`, optional, defaulting to True. The previous logging behavior (prior to `0.21.0`) can be enabled by setting `persist_logs` flag to `False` when calling `XProcess.ensure`.
- Fix resource warnings due to leaked internal file handles
- Ignore zombie processes which are erroneously considered alive with python 3.11