### PR TITLE
Drop scm versioning and update releasing steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,25 +45,3 @@ jobs:
     - name: Lint
       run: |
         tox -e linting
-  deploy:
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    runs-on: ubuntu-latest
-    needs: [build, linting]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.7"
-    - name: Install wheel
-      run: |
-        python -m pip install --upgrade pip setuptools
-        pip install wheel
-    - name: Build package
-      run: |
-        python setup.py sdist bdist_wheel
-    - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_token }}

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -24,18 +24,32 @@ Steps
 
     $ pip install tox
 
-#. Update the necessary files with::
+#. Run the test suite and ensure everything passes::
 
-    $ tox -e release -- X.Y.Z
+    $ tox
+
+#. Install ``twine``
+
+    $ pip install twine
 
 #. Commit and push the branch for review.
 
-#. Once PR is **green** and **approved**, create and push a tag::
+#. Once PR is **green** and **approved**, update `xprocess.__version__`::
 
-    $ export VERSION=X.Y.Z
-    $ git tag $VERSION release-$VERSION
-    $ git push git@github.com:pytest-dev/pytest-xprocess.git $VERSION
+#. Create source distribution and wheel
 
-    That will build the package and publish it on ``PyPI`` automatically.
+    $ python setup.py sdist bdist_wheel
+
+#. Check the created distribution files with twine
+
+    $ twine check dist/*
+
+#. Release to test pypi to ensure everything is OK
+
+    $ twine upload -r <testpypi> dist/*
+
+#. Finally, if everything looks fine on test pypi
+
+    $ twine upload -r pypi dist
 
 #. Merge ``release-X.Y.Z`` branch into master.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,13 @@
 [metadata]
 name = pytest-xprocess
+version = attr: xprocess.__version__
 author = Holger Krekel
 author_email = holger@merlinux.eu
 license = MIT
 license_files = LICENSE
 url = https://github.com/pytest-dev/pytest-xprocess/
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 description = A pytest plugin for managing processes across test runs.
 classifiers=
     Framework :: Pytest
@@ -23,8 +25,6 @@ classifiers=
 
 [options]
 packages = find:
-setup_requires=
-    setuptools_scm
 python_requires = >= 3.7
 
 [options.packages.find]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import setup
 if __name__ == "__main__":
     setup(
         name="pytest-xprocess",
-        use_scm_version=True,
         # this is for GitHub's dependency graph
         install_requires=["pytest>=2.8", "psutil", "py"],
     )

--- a/xprocess/__init__.py
+++ b/xprocess/__init__.py
@@ -9,3 +9,5 @@ __all__ = [
     "XProcessResources",
     "XProcessInfo",
 ]
+
+__version__ = "0.22.0"


### PR DESCRIPTION
Our `deploy` workflow by tag pushing is broken due to permission issues (probably expired token) and I have been doing the releases manually for a while now. Personally, I prefer it that way since it gives me more control over how the distro files are built and I can first release it to `https://test.pypi.org/` to ensure everything is fine prior to the actual release. I have updated the releasing steps with how I usually do it and also cleaned up our workflow file.