### PR TITLE
Use byte streams for all file handles

### DIFF
--- a/xprocess/xprocess.py
+++ b/xprocess/xprocess.py
@@ -202,7 +202,7 @@ class XProcess:
 
         return XProcessInfo(self.rootdir, name)
 
-    def ensure(self, name, preparefunc, restart=False, persist_logs=True):
+    def ensure(self, name, preparefunc, restart=False, persist_logs=False):
         """Returns (PID, logfile) from a newly started or already
             running process.
 
@@ -271,15 +271,17 @@ class XProcess:
             self.log.debug("process %r started pid=%s", name, pid)
             stdout.close()
 
-        log_file_handle = open(info.logpath, errors="ignore")
+        log_file_handle = open(info.logpath, "rb")
         # keep track of all file handles so we can
         # cleanup later during teardown phase
         xresource.fhandles.append(log_file_handle)
 
         if persist_logs:
             # skip previous process logs
-            process_log_block_handle = info.logpath.open()
-            lines = process_log_block_handle.readlines()
+            process_log_block_handle = open(info.logpath, "rb")
+            lines = [
+                str(line, "utf-8") for line in process_log_block_handle.readlines()
+            ]
             if lines:
                 proc_block_counter = sum(
                     1 for line in lines if XPROCESS_BLOCK_DELIMITER in line
@@ -381,14 +383,12 @@ class ProcessStarter(ABC):
 
     def startup_check(self):
         """Used to assert process responsiveness after pattern match"""
-
         return True
 
     def wait_callback(self):
         """Assert that process is ready to answer queries using provided
         callback funtion. Will raise TimeoutError if self.callback does not
         return True before self.timeout seconds"""
-
         while True:
             sleep(0.1)
             if self.startup_check():
@@ -404,7 +404,6 @@ class ProcessStarter(ABC):
 
     def wait(self, log_file):
         """Wait until the pattern is mached and callback returns successful."""
-
         self._max_time = datetime.now() + timedelta(seconds=self.timeout)
         lines = map(self.log_line, self.filter_lines(self.get_lines(log_file)))
         has_match = any(std.re.search(self.pattern, line) for line in lines)
@@ -413,13 +412,11 @@ class ProcessStarter(ABC):
 
     def filter_lines(self, lines):
         """fetch first <max_read_lines>, ignoring blank lines."""
-
         non_empty_lines = (x for x in lines if x.strip())
         return itertools.islice(non_empty_lines, self.max_read_lines)
 
     def log_line(self, line):
         """Write line to process log file."""
-
         self.process.log.debug(line)
         return line
 
@@ -427,9 +424,8 @@ class ProcessStarter(ABC):
         """Read and yield one line at a time from log_file. Will raise
         TimeoutError if pattern is not matched before self.timeout
         seconds."""
-
         while True:
-            line = log_file.readline()
+            line = str(log_file.readline(), "utf-8")
 
             if not line:
                 std.time.sleep(0.1)

--- a/xprocess/xprocess.py
+++ b/xprocess/xprocess.py
@@ -202,7 +202,7 @@ class XProcess:
 
         return XProcessInfo(self.rootdir, name)
 
-    def ensure(self, name, preparefunc, restart=False, persist_logs=False):
+    def ensure(self, name, preparefunc, restart=False, persist_logs=True):
         """Returns (PID, logfile) from a newly started or already
             running process.
 

--- a/xprocess/xprocess.py
+++ b/xprocess/xprocess.py
@@ -287,7 +287,7 @@ class XProcess:
                     1 for line in lines if XPROCESS_BLOCK_DELIMITER in line
                 )
                 for line in log_file_handle:
-                    if XPROCESS_BLOCK_DELIMITER in line:
+                    if XPROCESS_BLOCK_DELIMITER in str(line, "utf-8"):
                         proc_block_counter -= 1
                     if proc_block_counter <= 0:
                         break


### PR DESCRIPTION
Using both string and byte streams introduces unnecessary complexity which can cause issues such as #120. These changes make internal file handling homogeneous by using only byte streams everywhere.