### PR TITLE
Release 0.22.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-0.22.1 (UNRELEASED)
+0.22.1 (2023-01-05)
 -------------------
 
 - Python 3.10 is now officially supported


### PR DESCRIPTION
Our 0.22.1 release 🎉 

**Change Summary**

- Python 3.10 is now officially supported
- `surrogateescape` will now be used as error handling strategy for encode/decode operations. #127
- Make log files persistency, added in `0.21.0`, optional, defaulting to True. The previous logging behavior (prior to `0.21.0`) can be enabled by setting `persist_logs` flag to `False` when calling `XProcess.ensure`. #122
- Fix resource warnings due to leaked internal file handles #121
- Ignore zombie processes which are erroneously considered alive with python 3.11 #117