### PR TITLE
Release 0.22.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-0.22.1 (UNRELEASED)
+0.22.2 (2023-01-05)
 -------------------
 
 - Python 3.10 is now officially supported


### PR DESCRIPTION
Had an issue with deploy action and now previous release number is already taken on pypi 🥲 