### PR TITLE
Remove py dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+Unreleased
+----------
+
+- Remove dependency on `py`
+
 0.22.2 (2023-01-05)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,5 @@ if __name__ == "__main__":
     setup(
         name="pytest-xprocess",
         # this is for GitHub's dependency graph
-        install_requires=["pytest>=2.8", "psutil", "py"],
+        install_requires=["pytest>=2.8", "psutil"],
     )

--- a/xprocess/pytest_xprocess.py
+++ b/xprocess/pytest_xprocess.py
@@ -1,7 +1,7 @@
 import os
 
-import py
 import pytest
+from _pytest._io import TerminalWriter
 
 from xprocess import XProcess
 
@@ -35,7 +35,7 @@ def pytest_cmdline_main(config):
     xshow = config.option.xshow
     if xkill or xshow:
         config._do_configure()
-        tw = py.io.TerminalWriter()
+        tw = TerminalWriter()
         rootdir = getrootdir(config)
         xprocess = XProcess(config, rootdir)
     if xkill:

--- a/xprocess/xprocess.py
+++ b/xprocess/xprocess.py
@@ -1,7 +1,10 @@
 import itertools
 import os
+import re
 import signal
+import subprocess
 import sys
+import time
 import traceback
 from abc import ABC
 from abc import abstractmethod
@@ -10,7 +13,6 @@ from datetime import timedelta
 from time import sleep
 
 import psutil
-from py import std
 
 
 XPROCESS_BLOCK_DELIMITER = "@@__xproc_block_delimiter__@@"
@@ -250,9 +252,9 @@ class XProcess:
                 **starter.popen_kwargs,
             }
             if sys.platform == "win32":  # pragma: no cover
-                kwargs["startupinfo"] = sinfo = std.subprocess.STARTUPINFO()
-                sinfo.dwFlags |= std.subprocess.STARTF_USESHOWWINDOW
-                sinfo.wShowWindow |= std.subprocess.SW_HIDE
+                kwargs["startupinfo"] = sinfo = subprocess.STARTUPINFO()
+                sinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+                sinfo.wShowWindow |= subprocess.SW_HIDE
             else:
                 kwargs["close_fds"] = True
                 kwargs["preexec_fn"] = os.setpgrp  # no CONTROL-C
@@ -396,7 +398,7 @@ class ProcessStarter(ABC):
         """Wait until the pattern is mached and callback returns successful."""
         self._max_time = datetime.now() + timedelta(seconds=self.timeout)
         lines = map(self.log_line, self.filter_lines(self.get_lines(log_file)))
-        has_match = any(std.re.search(self.pattern, line) for line in lines)
+        has_match = any(re.search(self.pattern, line) for line in lines)
         process_ready = self.wait_callback()
         return has_match and process_ready
 
@@ -417,7 +419,7 @@ class ProcessStarter(ABC):
         while True:
             line = log_file.readline()
             if not line:
-                std.time.sleep(0.1)
+                time.sleep(0.1)
             if datetime.now() > self._max_time:
                 raise TimeoutError(
                     "The provided start pattern {} could not be matched \


### PR DESCRIPTION
The `py.std` module is just an alias for the built in Python modules, so doesn't serve any purpose over importing them directly.

`TerminalWriter` can instead be imported from Pytest directly via a private import, which means the `py` dependency can be removed.

This follows the suggestions from https://github.com/pytest-dev/pytest-xprocess/issues/110.

My motivation for doing this is that we hit `DeprecationWarnings` from `py` when using pytest-xprocess because we elevate warnings to errors when we run tests.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGELOG.rst`, summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and make sure  no tests failed.
