### PR TITLE
Drop support for Python 3.7, add support for Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,17 +6,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.8", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
-          - python: "3.10"
-            tox_env: "py310"
-          - python: "3.7"
-            tox_env: "py37"
           - python: "3.8"
             tox_env: "py38"
           - python: "3.9"
             tox_env: "py39"
+          - python: "3.10"
+            tox_env: "py310"
+          - python: "3.11"
+            tox_env: "py311"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Install wheel
         run: |
           python -m pip install --upgrade pip setuptools

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args: ["--py37-plus"]
+        args: ["--py38-plus"]
   - repo: https://github.com/asottile/reorder_python_imports
     rev: v3.9.0
     hooks:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+Unreleased
+----------
+
+- Drop support for Python 3.7
+- Add support for Python 3.11
+
 0.22.2 (2023-01-05)
 -------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,17 +14,17 @@ classifiers=
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Libraries
     Topic :: Utilities
 
 [options]
 packages = find:
-python_requires = >= 3.7
+python_requires = >= 3.8
 
 [options.packages.find]
 exclude = docs, tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=begin,py{37,38,39,310}
+envlist=begin,py{38,39,310,311}
 
 [testenv:dev]
 commands =


### PR DESCRIPTION
Python 3.7 reached end-of-life on 2023-06-27 so support for it can be dropped.

Python 3.11 was released on 2022-10-24 and has now reached version 3.11.5, so it deserves to be tested against.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGELOG.rst`, summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and make sure  no tests failed.
