### PR TITLE
release 0.23.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-0.23.0 (Unreleased)
+0.23.0 (2023-09-23)
 -------------------
 
 - Drop support for Python 3.7

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@ copyright = "2021, Holger Krekel"
 author = "Holger Krekel"
 
 # The full version, including alpha/beta/rc tags
-release = "0.18.1"
+release = "0.23.0"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Our 0.22.1 release 🎉

Change Summary

- Drop support for Python 3.7
- Add support for Python 3.11
- Remove dependency on `py`