### PR TITLE
Add required sphinx conf path to .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,3 +6,4 @@ build:
 sphinx:
   builder: dirhtml
   fail_on_warning: true
+  configuration: docs/source/conf.py


### PR DESCRIPTION
This is now required:

https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
