### PR TITLE
Fix coverage omit test filename

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps=
     coverage
 commands=
     coverage run -m pytest -v
-    coverage report --omit="*/.tox/*,*/test_functional_workflow.py" --fail-under=90
+    coverage report --omit="*/.tox/*,*/test_functional_work_flow.py" --fail-under=90
 usedevelop = True
 
 [testenv:linting]


### PR DESCRIPTION
Fixes #155.\n\nThe coverage omit pattern referenced test_functional_workflow.py, but the generated temporary test file uses test_functional_work_flow.py. This updates the omit pattern so coverage reports exclude the intended generated file.\n\nVerification:\n- tox-equivalent coverage repro from tests/ showing the old omit leaves test_functional_work_flow.py in the report and the new omit excludes it\n- python assertion that tox.ini references the actual filename\n- git diff --check\n\nNote: A broader local pytest run produced unrelated socket startup failures in test_process_initialization.py on this machine; 45 tests passed before those environment-dependent failures.